### PR TITLE
Add logger gem for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem "jekyll", "~> 4.0"
 gem "jekyll-last-modified-at", git: "https://github.com/maximevaillancourt/jekyll-last-modified-at", branch: "add-support-for-files-in-git-submodules"
 gem 'jekyll-toc'
 gem "jekyll-tabs"
+gem "logger"
 gem "webrick", "~> 1.7"
 gem "nokogiri"


### PR DESCRIPTION
logger was removed from Ruby's default gems in Ruby 4.0, causing
Jekyll builds to fail with "cannot load such file -- logger".

https://claude.ai/code/session_01NTZf5hq89nbNLTSiAzFpQY